### PR TITLE
multi-template file and renderResponse support

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -28,3 +28,87 @@ SSR.compileTemplate = function(name, content, options) {
 
   return Template[name] = eval(template);
 };
+
+SSR.headSections = {};
+
+SSR.loadTemplates = function(txt){
+  // find template sections with name and inner text section in the template text
+  var myRegexp = /\<template\s+name\s*=\s*['"](\S+)['"]\s*\>([\s\S]*?)\<\/template\s*>/g;
+  var match = myRegexp.exec(txt);
+
+  while (match != null) {      
+    try{
+      // for all the matches - compile the name(1) to text(2) using SSR
+      // console.log('compiling '+match[1]);
+      SSR.compileTemplate(match[1], match[2]);
+    }catch(e){
+      console.log('failed to compile template '+match[1] +' error:'+e);
+    }
+
+    // save this data in template 
+    
+    SSR.headSections[match[1]] = match[2];
+
+    // get next match
+    match = myRegexp.exec(txt);
+  }
+};
+
+SSR.renderResponse = function (template, data, response, meta){
+  // render the template itself using SSR
+  var res = SSR.render(template, data);
+
+  var output = "<!DOCTYPE html><html><head>";
+
+  // append a common head template - if present
+  if(SSR.headSections["head"])
+      output += SSR.headSections["head"];
+
+  // if template specific head is present - append that
+  if(SSR.headSections[template+"-head"])
+      output += SSR.headSections[template+"-head"];
+
+  // output += "<meta name='viewport' content='width=device-width, initial-scale=1'><meta charset='utf-8'>";
+
+  var contentType = "text/html";
+  // if meta has been defined in code - append it to the head
+  if(meta){
+    var keys = Object.keys(meta);       
+    for(var k in keys){
+      var key = keys[k];
+      var val = meta[key];
+      if(key === "title")
+      output= output + "<title>"+val+"</title>";
+      else{
+        if(val === "css")
+         output +="<link rel='stylesheet' href='"+key+"'>";
+        else{
+            if(val == "script")
+              output += "<script src='"+key+"'></script>"
+            else{
+              if(val == "content-type")
+                contentType = key;
+              else
+                output += "<meta name='"+key+"' content='"+val+"'>";
+            }
+        }
+      }
+    }
+  }
+
+  // append result
+  output += "</head><body>"+res+"</body></html>";
+
+  //in dev mode - disable caching of responses 
+  if(process.env.NODE_ENV === "development"){
+    response.setHeader('cache-control', 'no-cache');
+    response.setHeader('expires', '0');
+    response.setHeader('charset', 'utf-8');
+  }
+
+  // write out the whole result
+  response.writeHead(200, {'Content-Type': contentType});
+  response.write(output);
+  response.end();
+}
+ 


### PR DESCRIPTION
instead of compiling each template separately - added support to create single file using function 

SSR.loadTemplates(Assets.getText('templates.html') );

<!-- file: private/templates.html -->
<template name="mytemplate">
Hello {{username}}, <br>
Now time is: {{time}}
</template>
<template name="another">...</template>

SSR.renderResponse( templateName, data, responseStream, metadata) 
- renders the template with given data - and serves over http response with support for Head sections and metadata

e.g. 
Router.route('/hello', function(){
    SSR.renderResponse( "mytemplate", { username: "me", time: "now" }, this.response, {title: "mypage", keywords:"test,ssr" } );
});